### PR TITLE
Don't link if authority is only "end" characters

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -14,12 +14,13 @@ impl Scanner for UrlScanner {
         if colon > 0 && after_slash_slash < s.len() {
             if s[colon..].starts_with("://") {
                 if let Some(start) = self.find_start(&s[0..colon]) {
-                    let end = self.find_end(&s[after_slash_slash..]);
-                    let range = Range {
-                        start: start,
-                        end: after_slash_slash + end,
-                    };
-                    return Some(range);
+                    if let Some(end) = self.find_end(&s[after_slash_slash..]) {
+                        let range = Range {
+                            start: start,
+                            end: after_slash_slash + end,
+                        };
+                        return Some(range);
+                    }
                 }
             }
         }
@@ -57,7 +58,7 @@ impl UrlScanner {
         return first;
     }
 
-    fn find_end(&self, s: &str) -> usize {
+    fn find_end(&self, s: &str) -> Option<usize> {
         let mut round = 0;
         let mut square = 0;
         let mut curly = 0;
@@ -65,7 +66,7 @@ impl UrlScanner {
         let mut single_quote = false;
 
         let mut previous_can_be_last = true;
-        let mut end = 0;
+        let mut end = None;
 
         for (i, c) in s.char_indices() {
             let can_be_last = match c {
@@ -142,7 +143,7 @@ impl UrlScanner {
                 _ => true,
             };
             if can_be_last {
-                end = i + c.len_utf8();
+                end = Some(i + c.len_utf8());
             }
             previous_can_be_last = can_be_last;
         }

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -35,8 +35,14 @@ fn schemes() {
 }
 
 #[test]
-fn host_too_short() {
+fn authority() {
     assert_not_linked("ab://");
+    assert_not_linked("http://");
+    assert_not_linked("http:// ");
+    assert_not_linked("\"http://\"");
+    assert_not_linked("\"http://...\", ");
+
+    assert_linked("http://a.", "|http://a|.");
 }
 
 #[test]
@@ -179,9 +185,7 @@ fn fuzz() {
 }
 
 fn assert_not_linked(s: &str) {
-    let finder = LinkFinder::new();
-    let result = finder.links(s);
-    assert_eq!(result.count(), 0, "expected no links in {:?}", s);
+    assert_linked(s, s);
 }
 
 fn assert_linked(input: &str, expected: &str) {


### PR DESCRIPTION
This change stops these and other examples from being linked:

    http://.
    http://"
    http://<space>

Note that `http://` and `http://.` are valid URLs according to RFC 3986,
because `authority` can be zero or more `unreserved` characters. But we
don't link `http://` on its own or the trailing `.` of
`http://example.org.`

(See https://github.com/robinst/autolink-java/issues/15)