### PR TITLE
Add iterator over spans

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,33 @@
 //! assert_eq!(&LinkKind::Email, link.kind());
 //! ```
 //!
+//! Split the text into consecutive spans (mixed links and plain text).
+//!
+//! ```
+//! use linkify::{LinkFinder, LinkKind};
+//!
+//! let input = "Have you seen http://example.com?";
+//! let finder = LinkFinder::new();
+//! let spans: Vec<_> = finder.spans(input).collect();
+//!
+//! assert_eq!(3, spans.len());
+//!
+//! assert_eq!("Have you seen ", spans[0].as_str());
+//! assert_eq!(0, spans[0].start());
+//! assert_eq!(14, spans[0].end());
+//! assert_eq!(None, spans[0].kind());
+//!
+//! assert_eq!("http://example.com", spans[1].as_str());
+//! assert_eq!(14, spans[1].start());
+//! assert_eq!(32, spans[1].end());
+//! assert_eq!(Some(&LinkKind::Url), spans[1].kind());
+//!
+//! assert_eq!("?", spans[2].as_str());
+//! assert_eq!(32, spans[2].start());
+//! assert_eq!(33, spans[2].end());
+//! assert_eq!(None, spans[2].kind());
+//! ```
+//!
 //! ### Conformance
 //!
 //! This crates makes an effort to respect the various standards, namely:
@@ -89,3 +116,4 @@ pub use finder::Link;
 pub use finder::LinkFinder;
 pub use finder::LinkKind;
 pub use finder::Links;
+pub use finder::{Span, Spans};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,14 +8,14 @@ pub fn assert_linked_with(finder: &LinkFinder, input: &str, expected: &str) {
 pub fn show_links(input: &str, finder: &LinkFinder) -> String {
     let mut result = String::new();
 
-    let mut i = 0;
-    for link in finder.links(input) {
-        result.push_str(&input[i..link.start()]);
-        i = link.end();
-        result.push('|');
-        result.push_str(link.as_str());
-        result.push('|');
+    for span in finder.spans(input) {
+        if span.kind().is_some() {
+            result.push('|');
+            result.push_str(span.as_str());
+            result.push('|');
+        } else {
+            result.push_str(span.as_str());
+        }
     }
-    result.push_str(&input[i..]);
     result
 }


### PR DESCRIPTION
When using link detection to edit parts of an input text (e.g. to add `<a>` tags), is it useful to be able to iterate over all parts of the input, not just the detected links.

This change adds the concept of a `Span`, which can either be a detected link, or just plain text, as well as an iterator `Spans`, that will emit consecutive spans from an input text.