### PR TITLE
Add support for grave quotes (`)

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -64,6 +64,7 @@ impl UrlScanner {
         let mut curly = 0;
         let mut double_quote = false;
         let mut single_quote = false;
+        let mut grave_accent = false;
 
         let mut previous_can_be_last = true;
         let mut end = None;
@@ -139,6 +140,11 @@ impl UrlScanner {
                     single_quote = !single_quote;
                     // A single quote can only be the end of an URL if there's an even number
                     !single_quote
+                }
+                '`' => {
+                    grave_accent = !grave_accent;
+                    // A grave accent can only be the end of an URL if there's an even number
+                    !grave_accent
                 }
                 _ => true,
             };

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -121,17 +121,36 @@ fn matching_punctuation_tricky() {
     assert_linked("http://example.org/]()", "|http://example.org/|]()");
 }
 
+fn quote(quote_char: char) {
+    assert_linked(&format!("http://example.org/{}_(foo)", quote_char),
+                  &format!("|http://example.org/{}_(foo)|", quote_char));
+    assert_linked(&format!("http://example.org/{}_(foo){0}", quote_char),
+                  &format!("|http://example.org/{}_(foo){0}|", quote_char));
+    assert_linked(&format!("http://example.org/{}{0}", quote_char),
+                  &format!("|http://example.org/{}{0}|", quote_char));
+    assert_linked(&format!("http://example.org/{}{0}{0}", quote_char),
+                  &format!("|http://example.org/{}{0}|{0}", quote_char));
+    assert_linked(&format!("http://example.org/{}.", quote_char),
+                  &format!("|http://example.org/|{}.", quote_char));
+    assert_linked(&format!("http://example.org/{}a", quote_char),
+                  &format!("|http://example.org/{}a|", quote_char));
+    assert_linked(&format!("http://example.org/it{}s", quote_char),
+                  &format!("|http://example.org/it{}s|", quote_char));
+}
+
 #[test]
-fn quotes() {
-    assert_linked("http://example.org/\"_(foo)",
-                  "|http://example.org/\"_(foo)|");
-    assert_linked("http://example.org/\"_(foo)\"",
-                  "|http://example.org/\"_(foo)\"|");
-    assert_linked("http://example.org/\"\"", "|http://example.org/\"\"|");
-    assert_linked("http://example.org/\"\"\"", "|http://example.org/\"\"|\"");
-    assert_linked("http://example.org/\".", "|http://example.org/|\".");
-    assert_linked("http://example.org/\"a", "|http://example.org/\"a|");
-    assert_linked("http://example.org/it's", "|http://example.org/it's|");
+fn double_quote() {
+    quote('"');
+}
+
+#[test]
+fn single_quote() {
+    quote('\'');
+}
+
+#[test]
+fn grave_quote() {
+    quote('`');
 }
 
 #[test]


### PR DESCRIPTION
URLs using ' or " as quotes already work very well with this library,
however when specifying a link using the grave accent quotes, it will
incorrectly include the trailing ` inside the URL.

Example:
  "URL: `https://example.com`" -> "https://example.com`"

Since grave accents can be used in markdown files to indicate inline
code blocks, I think it's a good idea to accept them as alternative
quote characters.