### PR TITLE
Add toggle to make URL schemes optional

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -130,3 +130,17 @@ impl EmailScanner {
         }
     }
 }
+
+/// Helper function to check if given string is considered an email address.
+#[inline]
+pub(crate) fn is_mail(input: &str) -> bool {
+    input
+        .char_indices()
+        .filter(|(_, c)| *c == '@')
+        .any(|(i, _)| {
+            let scanner = EmailScanner {
+                domain_must_have_dot: true,
+            };
+            scanner.scan(input, i).is_some()
+        })
+}

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -212,9 +212,7 @@ impl<'t> Links<'t> {
         email: bool,
         email_domain_must_have_dot: bool,
     ) -> Links<'t> {
-        let url_scanner = UrlScanner {
-            must_have_scheme: url_must_have_scheme,
-        };
+        let url_scanner = UrlScanner;
         let email_scanner = EmailScanner {
             domain_must_have_dot: email_domain_must_have_dot,
         };

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -1,8 +1,7 @@
 use std::fmt;
 use std::iter::Peekable;
 
-use memchr::memchr;
-use memchr::memchr2;
+use memchr::{memchr, memchr2, memchr3};
 
 use crate::email::EmailScanner;
 use crate::scanner::Scanner;
@@ -102,6 +101,7 @@ pub struct LinkFinder {
     email: bool,
     email_domain_must_have_dot: bool,
     url: bool,
+    url_no_proto: bool,
 }
 
 /// Iterator for finding links.
@@ -131,6 +131,8 @@ impl LinkFinder {
             email: true,
             email_domain_must_have_dot: true,
             url: true,
+            // TODO(timvisee): default this to false
+            url_no_proto: false,
         }
     }
 
@@ -138,6 +140,16 @@ impl LinkFinder {
     /// Use `false` to also find addresses such as `root@localhost`.
     pub fn email_domain_must_have_dot(&mut self, value: bool) -> &mut LinkFinder {
         self.email_domain_must_have_dot = value;
+        self
+    }
+
+    /// Define whether URLs require a protocol definition.
+    ///
+    /// By default only URLs having an `https://` protocol definition are found.
+    /// You may disable this to also find `example.org`. The protocol definition may be important
+    /// though, and disabling this may lead to finding a lot of false positive links.
+    pub fn url_no_protocol(&mut self, url_no_proto: bool) -> &mut LinkFinder {
+        self.url_no_proto = url_no_proto;
         self
     }
 
@@ -159,7 +171,13 @@ impl LinkFinder {
     ///
     /// Returns an `Iterator` which only scans when `next` is called (lazy).
     pub fn links<'t>(&self, text: &'t str) -> Links<'t> {
-        Links::new(text, self.url, self.email, self.email_domain_must_have_dot)
+        Links::new(
+            text,
+            self.url,
+            self.url_no_proto,
+            self.email,
+            self.email_domain_must_have_dot,
+        )
     }
 
     /// Iterate over spans in the specified input text.
@@ -187,14 +205,27 @@ impl Default for LinkFinder {
 }
 
 impl<'t> Links<'t> {
-    fn new(text: &'t str, url: bool, email: bool, email_domain_must_have_dot: bool) -> Links<'t> {
-        let url_scanner = UrlScanner {};
+    fn new(
+        text: &'t str,
+        url: bool,
+        url_no_proto: bool,
+        email: bool,
+        email_domain_must_have_dot: bool,
+    ) -> Links<'t> {
+        let url_scanner = UrlScanner {
+            no_proto: url_no_proto,
+        };
         let email_scanner = EmailScanner {
             domain_must_have_dot: email_domain_must_have_dot,
         };
+        // TODO(timvisee): do we need to update this for `no_proto`?
         let trigger_finder: Box<dyn Fn(&[u8]) -> Option<usize>> = match (url, email) {
+            (true, true) if url_no_proto => Box::new(|s| memchr3(b':', b'@', b'.', s)),
             (true, true) => Box::new(|s| memchr2(b':', b'@', s)),
+            (true, false) if url_no_proto => Box::new(|s| memchr2(b':', b'.', s)),
             (true, false) => Box::new(|s| memchr(b':', s)),
+            // (true, true) => Box::new(|s| memchr2(b':', b'@', s)),
+            // (true, false) => Box::new(|s| memchr(b':', s)),
             (false, true) => Box::new(|s| memchr(b'@', s)),
             (false, false) => Box::new(|_| None),
         };
@@ -217,8 +248,10 @@ impl<'t> Iterator for Links<'t> {
         let mut find_from = 0;
         while let Some(i) = (self.trigger_finder)(slice[find_from..].as_bytes()) {
             let trigger = slice.as_bytes()[find_from + i];
+            // TODO(timvisee): do we need to update this for `no_proto`?
             let (scanner, kind): (&dyn Scanner, LinkKind) = match trigger {
-                b':' => (&self.url_scanner, LinkKind::Url),
+                b':' | b'.' => (&self.url_scanner, LinkKind::Url),
+                // b':' => (&self.url_scanner, LinkKind::Url),
                 b'@' => (&self.email_scanner, LinkKind::Email),
                 _ => unreachable!(),
             };

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -101,7 +101,7 @@ pub struct LinkFinder {
     email: bool,
     email_domain_must_have_dot: bool,
     url: bool,
-    url_optional_scheme: bool,
+    url_must_have_scheme: bool,
 }
 
 /// Iterator for finding links.
@@ -131,7 +131,7 @@ impl LinkFinder {
             email: true,
             email_domain_must_have_dot: true,
             url: true,
-            url_optional_scheme: false,
+            url_must_have_scheme: true,
         }
     }
 
@@ -142,14 +142,14 @@ impl LinkFinder {
         self
     }
 
-    /// Define whether URL schemes such as `https` are optional.
+    /// Set whether URLs must have a scheme, defaults to `true`.
     ///
     /// By default only URLs having a scheme defined are found.
-    /// By setting this to `true` you make the scheme of URLs optional, to also find URLs like
+    /// By setting this to `false` you make the scheme of URLs optional, to also find URLs like
     /// `example.org`. For some URLs the used scheme is important, and making the scheme optional
     /// may lead to finding a lot of false positive URLs.
-    pub fn url_optional_scheme(&mut self, url_optional_scheme: bool) -> &mut LinkFinder {
-        self.url_optional_scheme = url_optional_scheme;
+    pub fn url_must_have_scheme(&mut self, url_must_have_scheme: bool) -> &mut LinkFinder {
+        self.url_must_have_scheme = url_must_have_scheme;
         self
     }
 
@@ -174,7 +174,7 @@ impl LinkFinder {
         Links::new(
             text,
             self.url,
-            self.url_optional_scheme,
+            self.url_must_have_scheme,
             self.email,
             self.email_domain_must_have_dot,
         )
@@ -208,12 +208,12 @@ impl<'t> Links<'t> {
     fn new(
         text: &'t str,
         url: bool,
-        url_optional_scheme: bool,
+        url_must_have_scheme: bool,
         email: bool,
         email_domain_must_have_dot: bool,
     ) -> Links<'t> {
         let url_scanner = UrlScanner {
-            optional_scheme: url_optional_scheme,
+            must_have_scheme: url_must_have_scheme,
         };
         let email_scanner = EmailScanner {
             domain_must_have_dot: email_domain_must_have_dot,
@@ -221,10 +221,10 @@ impl<'t> Links<'t> {
 
         // With optional schemes URLs don't have unique `:`, then search for `.` as well
         let trigger_finder: Box<dyn Fn(&[u8]) -> Option<usize>> = match (url, email) {
-            (true, true) if url_optional_scheme => Box::new(|s| memchr3(b':', b'@', b'.', s)),
-            (true, true) => Box::new(|s| memchr2(b':', b'@', s)),
-            (true, false) if url_optional_scheme => Box::new(|s| memchr2(b':', b'.', s)),
-            (true, false) => Box::new(|s| memchr(b':', s)),
+            (true, true) if url_must_have_scheme => Box::new(|s| memchr2(b':', b'@', s)),
+            (true, true) => Box::new(|s| memchr3(b':', b'@', b'.', s)),
+            (true, false) if url_must_have_scheme => Box::new(|s| memchr(b':', s)),
+            (true, false) => Box::new(|s| memchr2(b':', b'.', s)),
             (false, true) => Box::new(|s| memchr(b'@', s)),
             (false, false) => Box::new(|_| None),
         };

--- a/src/url.rs
+++ b/src/url.rs
@@ -7,18 +7,15 @@ const QUOTES: &[char] = &['\'', '\"'];
 /// Scan for URLs starting from the trigger character ":", requires "://".
 ///
 /// Based on RFC 3986.
-pub struct UrlScanner {
-    /// Whether URLs must have a scheme.
-    ///
-    /// Setting this to `false` allows to find URLs without a scheme such as `https` as well,
-    /// to make links like `example.org` findable. For some URLs the specific scheme
-    /// that is used is important, and disabling this need may lead to false positives and must be
-    /// filtered by the end user.
-    /// Please note that this finds URLs not specified in the RFC.
-    pub must_have_scheme: bool,
-}
+pub struct UrlScanner;
 
 impl Scanner for UrlScanner {
+    /// Scan for an URL at the given separator index in the string.
+    ///
+    /// The kind of separator that was used (`://` vs `.`) has effect on whether URLs with no
+    /// schemes are found.
+    ///
+    /// Returns `None` if none was found, or if an invalid separator index was given.
     fn scan(&self, s: &str, separator: usize) -> Option<Range<usize>> {
         // There must be something before separator for scheme or host
         if separator == 0 {

--- a/src/url.rs
+++ b/src/url.rs
@@ -8,14 +8,14 @@ const QUOTES: &[char] = &['\'', '\"'];
 ///
 /// Based on RFC 3986.
 pub struct UrlScanner {
-    /// Whether URL schemes such as `https` are optional.
+    /// Whether URLs must have a scheme.
     ///
-    /// Setting this to `true` allows to find URLs without a scheme such as `https` as well,
+    /// Setting this to `false` allows to find URLs without a scheme such as `https` as well,
     /// to make links like `example.org` findable. For some URLs the specific scheme
-    /// that is used is important, and disabling this need may lead to a lot of false positive
-    /// links which should be filtered by the end user.
+    /// that is used is important, and disabling this need may lead to false positives and must be
+    /// filtered by the end user.
     /// Please note that this finds URLs not specified in the RFC.
-    pub optional_scheme: bool,
+    pub must_have_scheme: bool,
 }
 
 impl Scanner for UrlScanner {

--- a/src/url.rs
+++ b/src/url.rs
@@ -67,15 +67,18 @@ impl UrlScanner {
                     special = Some(i)
                 }
                 '+' | '-' | '.' => {}
-                _ => {
+                c if QUOTES.contains(&c) => {
                     // Check if there's a quote before the scheme,
                     // and stop once we encounter one of those quotes.
                     // https://github.com/robinst/linkify/issues/20
-                    if QUOTES.contains(&c) {
-                        quote = Some(c);
-                    }
-                    break;
+                    quote = Some(c);
                 }
+                c if !has_scheme && !matches!(c, '(' | ')' | '[' | ']' | '{' | '}' | ' ') => {
+                    // Detect the start for links using unicode when having links without a scheme,
+                    // then looking for ASCII alpha characters is not enough
+                    first = Some(i);
+                }
+                _ => break,
             }
         }
 

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -414,6 +414,21 @@ fn international_without_protocol() {
 }
 
 #[test]
+fn domain_tld_without_protocol_must_be_long() {
+    assert_linked_without_protocol("example.", "example.");
+    assert_linked_without_protocol("example./", "example./");
+    assert_linked_without_protocol("foo.example.", "foo.example.");
+    assert_linked_without_protocol("example.c", "example.c");
+    assert_linked_without_protocol("example.co", "|example.co|");
+    assert_linked_without_protocol("example.com", "|example.com|");
+    assert_linked_without_protocol("e.com", "|e.com|");
+    assert_linked_without_protocol("exampl.e.c", "exampl.e.c");
+    assert_linked_without_protocol("exampl.e.co", "|exampl.e.co|");
+    assert_linked_without_protocol("e.xample.c", "e.xample.c");
+    assert_linked_without_protocol("e.xample.co", "|e.xample.co|");
+}
+
+#[test]
 fn skip_emails_without_protocol() {
     assert_not_linked_without_protocol("foo.bar@example.org");
 }

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use crate::common::assert_linked_with;
-use linkify::LinkFinder;
+use linkify::{LinkFinder, LinkKind};
 
 #[test]
 fn no_links() {
@@ -69,14 +69,14 @@ fn single_links() {
 
 #[test]
 fn single_links_without_protocol() {
-    assert_linked_without_protocol("example.org/", "|example.org/|");
-    assert_linked_without_protocol("example.org/123", "|example.org/123|");
-    assert_linked_without_protocol(
+    assert_urls_without_protocol("example.org/", "|example.org/|");
+    assert_urls_without_protocol("example.org/123", "|example.org/123|");
+    assert_urls_without_protocol(
         "example.org/?foo=test&bar=123",
         "|example.org/?foo=test&bar=123|",
     );
-    assert_linked_without_protocol("example.org/?foo=%20", "|example.org/?foo=%20|");
-    assert_linked_without_protocol("example.org/%3C", "|example.org/%3C|");
+    assert_urls_without_protocol("example.org/?foo=%20", "|example.org/?foo=%20|");
+    assert_urls_without_protocol("example.org/%3C", "|example.org/%3C|");
 }
 
 #[test]
@@ -98,13 +98,13 @@ fn space_characters_stop_url() {
 
 #[test]
 fn space_characters_stop_url_without_protocol() {
-    assert_linked_without_protocol("foo example.org/", "foo |example.org/|");
-    assert_linked_without_protocol("example.org/ bar", "|example.org/| bar");
-    assert_linked_without_protocol("example.org/\tbar", "|example.org/|\tbar");
-    assert_linked_without_protocol("example.org/\nbar", "|example.org/|\nbar");
-    assert_linked_without_protocol("example.org/\u{0B}bar", "|example.org/|\u{0B}bar");
-    assert_linked_without_protocol("example.org/\u{0C}bar", "|example.org/|\u{0C}bar");
-    assert_linked_without_protocol("example.org/\rbar", "|example.org/|\rbar");
+    assert_urls_without_protocol("foo example.org/", "foo |example.org/|");
+    assert_urls_without_protocol("example.org/ bar", "|example.org/| bar");
+    assert_urls_without_protocol("example.org/\tbar", "|example.org/|\tbar");
+    assert_urls_without_protocol("example.org/\nbar", "|example.org/|\nbar");
+    assert_urls_without_protocol("example.org/\u{0B}bar", "|example.org/|\u{0B}bar");
+    assert_urls_without_protocol("example.org/\u{0C}bar", "|example.org/|\u{0C}bar");
+    assert_urls_without_protocol("example.org/\rbar", "|example.org/|\rbar");
 }
 
 #[test]
@@ -121,13 +121,13 @@ fn illegal_characters_stop_url() {
 
 #[test]
 fn illegal_characters_stop_url_without_protocol() {
-    assert_linked_without_protocol("example.org/<", "|example.org/|<");
-    assert_linked_without_protocol("example.org/>", "|example.org/|>");
-    assert_linked_without_protocol("example.org/<>", "|example.org/|<>");
-    assert_linked_without_protocol("example.org/\u{00}", "|example.org/|\u{00}");
-    assert_linked_without_protocol("example.org/\u{0E}", "|example.org/|\u{0E}");
-    assert_linked_without_protocol("example.org/\u{7F}", "|example.org/|\u{7F}");
-    assert_linked_without_protocol("example.org/\u{9F}", "|example.org/|\u{9F}");
+    assert_urls_without_protocol("example.org/<", "|example.org/|<");
+    assert_urls_without_protocol("example.org/>", "|example.org/|>");
+    assert_urls_without_protocol("example.org/<>", "|example.org/|<>");
+    assert_urls_without_protocol("example.org/\u{00}", "|example.org/|\u{00}");
+    assert_urls_without_protocol("example.org/\u{0E}", "|example.org/|\u{0E}");
+    assert_urls_without_protocol("example.org/\u{7F}", "|example.org/|\u{7F}");
+    assert_urls_without_protocol("example.org/\u{9F}", "|example.org/|\u{9F}");
 }
 
 #[test]
@@ -143,13 +143,13 @@ fn delimiter_at_end() {
 
 #[test]
 fn delimiter_at_end_no_protocol() {
-    assert_linked_without_protocol("example.org/.", "|example.org/|.");
-    assert_linked_without_protocol("example.org/..", "|example.org/|..");
-    assert_linked_without_protocol("example.org/,", "|example.org/|,");
-    assert_linked_without_protocol("example.org/:", "|example.org/|:");
-    assert_linked_without_protocol("example.org/?", "|example.org/|?");
-    assert_linked_without_protocol("example.org/!", "|example.org/|!");
-    assert_linked_without_protocol("example.org/;", "|example.org/|;");
+    assert_urls_without_protocol("example.org/.", "|example.org/|.");
+    assert_urls_without_protocol("example.org/..", "|example.org/|..");
+    assert_urls_without_protocol("example.org/,", "|example.org/|,");
+    assert_urls_without_protocol("example.org/:", "|example.org/|:");
+    assert_urls_without_protocol("example.org/?", "|example.org/|?");
+    assert_urls_without_protocol("example.org/!", "|example.org/|!");
+    assert_urls_without_protocol("example.org/;", "|example.org/|;");
 }
 
 #[test]
@@ -166,15 +166,15 @@ fn matching_punctuation() {
 }
 #[test]
 fn matching_punctuation_without_protocol() {
-    assert_linked_without_protocol("example.org/a(b)", "|example.org/a(b)|");
-    assert_linked_without_protocol("example.org/a[b]", "|example.org/a[b]|");
-    assert_linked_without_protocol("example.org/a{b}", "|example.org/a{b}|");
-    assert_linked_without_protocol("example.org/a'b'", "|example.org/a'b'|");
-    assert_linked_without_protocol("(example.org/)", "(|example.org/|)");
-    assert_linked_without_protocol("[example.org/]", "[|example.org/|]");
-    assert_linked_without_protocol("{example.org/}", "{|example.org/|}");
-    assert_linked_without_protocol("\"example.org/\"", "\"|example.org/|\"");
-    assert_linked_without_protocol("'example.org/'", "'|example.org/|'");
+    assert_urls_without_protocol("example.org/a(b)", "|example.org/a(b)|");
+    assert_urls_without_protocol("example.org/a[b]", "|example.org/a[b]|");
+    assert_urls_without_protocol("example.org/a{b}", "|example.org/a{b}|");
+    assert_urls_without_protocol("example.org/a'b'", "|example.org/a'b'|");
+    assert_urls_without_protocol("(example.org/)", "(|example.org/|)");
+    assert_urls_without_protocol("[example.org/]", "[|example.org/|]");
+    assert_urls_without_protocol("{example.org/}", "{|example.org/|}");
+    assert_urls_without_protocol("\"example.org/\"", "\"|example.org/|\"");
+    assert_urls_without_protocol("'example.org/'", "'|example.org/|'");
 }
 
 #[test]
@@ -196,16 +196,16 @@ fn matching_punctuation_tricky() {
 
 #[test]
 fn matching_punctuation_tricky_without_protocol() {
-    assert_linked_without_protocol("((example.org/))", "((|example.org/|))");
-    assert_linked_without_protocol("((example.org/a(b)))", "((|example.org/a(b)|))");
-    assert_linked_without_protocol("[(example.org/)]", "[(|example.org/|)]");
-    assert_linked_without_protocol("(example.org/).", "(|example.org/|).");
-    assert_linked_without_protocol("(example.org/.)", "(|example.org/|.)");
-    assert_linked_without_protocol("example.org/>", "|example.org/|>");
+    assert_urls_without_protocol("((example.org/))", "((|example.org/|))");
+    assert_urls_without_protocol("((example.org/a(b)))", "((|example.org/a(b)|))");
+    assert_urls_without_protocol("[(example.org/)]", "[(|example.org/|)]");
+    assert_urls_without_protocol("(example.org/).", "(|example.org/|).");
+    assert_urls_without_protocol("(example.org/.)", "(|example.org/|.)");
+    assert_urls_without_protocol("example.org/>", "|example.org/|>");
     // not sure about these
-    assert_linked_without_protocol("example.org/(", "|example.org/|(");
-    assert_linked_without_protocol("example.org/(.", "|example.org/|(.");
-    assert_linked_without_protocol("example.org/]()", "|example.org/|]()");
+    assert_urls_without_protocol("example.org/(", "|example.org/|(");
+    assert_urls_without_protocol("example.org/(.", "|example.org/|(.");
+    assert_urls_without_protocol("example.org/]()", "|example.org/|]()");
 }
 
 #[test]
@@ -232,13 +232,13 @@ fn single_quote() {
 
 #[test]
 fn single_quote_without_protocol() {
-    assert_linked_without_protocol("example.org/\'_(foo)", "|example.org/\'_(foo)|");
-    assert_linked_without_protocol("example.org/\'_(foo)\'", "|example.org/\'_(foo)\'|");
-    assert_linked_without_protocol("example.org/\'\'", "|example.org/\'\'|");
-    assert_linked_without_protocol("example.org/\'\'\'", "|example.org/\'\'|\'");
-    assert_linked_without_protocol("example.org/\'.", "|example.org/|\'.");
-    assert_linked_without_protocol("example.org/\'a", "|example.org/\'a|");
-    assert_linked_without_protocol("example.org/it's", "|example.org/it's|");
+    assert_urls_without_protocol("example.org/\'_(foo)", "|example.org/\'_(foo)|");
+    assert_urls_without_protocol("example.org/\'_(foo)\'", "|example.org/\'_(foo)\'|");
+    assert_urls_without_protocol("example.org/\'\'", "|example.org/\'\'|");
+    assert_urls_without_protocol("example.org/\'\'\'", "|example.org/\'\'|\'");
+    assert_urls_without_protocol("example.org/\'.", "|example.org/|\'.");
+    assert_urls_without_protocol("example.org/\'a", "|example.org/\'a|");
+    assert_urls_without_protocol("example.org/it's", "|example.org/it's|");
 }
 
 #[test]
@@ -266,8 +266,8 @@ fn asterisk() {
 #[test]
 fn grave_quote_without_protocol() {
     // ` not allowed in URLs
-    assert_linked_without_protocol("example.org/`a", "|example.org/|`a");
-    assert_linked_without_protocol("example.org/`a`", "|example.org/|`a`");
+    assert_urls_without_protocol("example.org/`a", "|example.org/|`a");
+    assert_urls_without_protocol("example.org/`a`", "|example.org/|`a`");
 }
 
 #[test]
@@ -282,12 +282,12 @@ fn html() {
 
 #[test]
 fn html_no_protocol() {
-    assert_linked_without_protocol("example.org\">", "|example.org|\">");
-    assert_linked_without_protocol("example.org'>", "|example.org|'>");
-    assert_linked_without_protocol("example.org\"/>", "|example.org|\"/>");
-    assert_linked_without_protocol("example.org'/>", "|example.org|'/>");
-    assert_linked_without_protocol("example.org<p>", "|example.org|<p>");
-    assert_linked_without_protocol("example.org</p>", "|example.org|</p>");
+    assert_urls_without_protocol("example.org\">", "|example.org|\">");
+    assert_urls_without_protocol("example.org'>", "|example.org|'>");
+    assert_urls_without_protocol("example.org\"/>", "|example.org|\"/>");
+    assert_urls_without_protocol("example.org'/>", "|example.org|'/>");
+    assert_urls_without_protocol("example.org<p>", "|example.org|<p>");
+    assert_urls_without_protocol("example.org</p>", "|example.org|</p>");
 }
 
 #[test]
@@ -332,8 +332,8 @@ fn complex_html() {
 
 #[test]
 fn css_without_protocol() {
-    assert_linked_without_protocol("example.org\");", "|example.org|\");");
-    assert_linked_without_protocol("example.org');", "|example.org|');");
+    assert_urls_without_protocol("example.org\");", "|example.org|\");");
+    assert_urls_without_protocol("example.org');", "|example.org|');");
 }
 
 #[test]
@@ -345,9 +345,9 @@ fn slash() {
 
 #[test]
 fn slash_without_protocol() {
-    assert_linked_without_protocol("example.org/", "|example.org/|");
-    assert_linked_without_protocol("example.org/a/", "|example.org/a/|");
-    assert_linked_without_protocol("example.org//", "|example.org//|");
+    assert_urls_without_protocol("example.org/", "|example.org/|");
+    assert_urls_without_protocol("example.org/a/", "|example.org/a/|");
+    assert_urls_without_protocol("example.org//", "|example.org//|");
 }
 
 #[test]
@@ -367,19 +367,19 @@ fn multiple() {
 }
 #[test]
 fn multiple_without_protocol() {
-    assert_linked_without_protocol("one.org/ two.org/", "|one.org/| |two.org/|");
-    assert_linked_without_protocol("one.org/ : two.org/", "|one.org/| : |two.org/|");
-    assert_linked_without_protocol("(one.org/)(two.org/)", "(|one.org/|)(|two.org/|)");
+    assert_urls_without_protocol("one.org/ two.org/", "|one.org/| |two.org/|");
+    assert_urls_without_protocol("one.org/ : two.org/", "|one.org/| : |two.org/|");
+    assert_urls_without_protocol("(one.org/)(two.org/)", "(|one.org/|)(|two.org/|)");
 }
 
 #[test]
 fn multiple_mixed_protocol() {
-    assert_linked_without_protocol("http://one.org/ two.org/", "|http://one.org/| |two.org/|");
-    assert_linked_without_protocol(
+    assert_urls_without_protocol("http://one.org/ two.org/", "|http://one.org/| |two.org/|");
+    assert_urls_without_protocol(
         "one.org/ : http://two.org/",
         "|one.org/| : |http://two.org/|",
     );
-    assert_linked_without_protocol(
+    assert_urls_without_protocol(
         "(http://one.org/)(two.org/)",
         "(|http://one.org/|)(|two.org/|)",
     );
@@ -404,28 +404,28 @@ fn international() {
 
 #[test]
 fn international_without_protocol() {
-    assert_linked_without_protocol("üñîçøðé.com", "|üñîçøðé.com|");
-    assert_linked_without_protocol("üñîçøðé.com/ä", "|üñîçøðé.com/ä|");
-    assert_linked_without_protocol("example.org/\u{A1}", "|example.org/\u{A1}|");
-    assert_linked_without_protocol("example.org/\u{A2}", "|example.org/\u{A2}|");
-    assert_linked_without_protocol("example.org/\u{1F600}", "|example.org/\u{1F600}|");
-    assert_linked_without_protocol("example.org/\u{A2}/", "|example.org/\u{A2}/|");
-    assert_linked_without_protocol("xn--c1h.example.com/", "|xn--c1h.example.com/|");
+    assert_urls_without_protocol("üñîçøðé.com", "|üñîçøðé.com|");
+    assert_urls_without_protocol("üñîçøðé.com/ä", "|üñîçøðé.com/ä|");
+    assert_urls_without_protocol("example.org/\u{A1}", "|example.org/\u{A1}|");
+    assert_urls_without_protocol("example.org/\u{A2}", "|example.org/\u{A2}|");
+    assert_urls_without_protocol("example.org/\u{1F600}", "|example.org/\u{1F600}|");
+    assert_urls_without_protocol("example.org/\u{A2}/", "|example.org/\u{A2}/|");
+    assert_urls_without_protocol("xn--c1h.example.com/", "|xn--c1h.example.com/|");
 }
 
 #[test]
 fn domain_tld_without_protocol_must_be_long() {
-    assert_linked_without_protocol("example.", "example.");
-    assert_linked_without_protocol("example./", "example./");
-    assert_linked_without_protocol("foo.example.", "foo.example.");
-    assert_linked_without_protocol("example.c", "example.c");
-    assert_linked_without_protocol("example.co", "|example.co|");
-    assert_linked_without_protocol("example.com", "|example.com|");
-    assert_linked_without_protocol("e.com", "|e.com|");
-    assert_linked_without_protocol("exampl.e.c", "exampl.e.c");
-    assert_linked_without_protocol("exampl.e.co", "|exampl.e.co|");
-    assert_linked_without_protocol("e.xample.c", "e.xample.c");
-    assert_linked_without_protocol("e.xample.co", "|e.xample.co|");
+    assert_urls_without_protocol("example.", "example.");
+    assert_urls_without_protocol("example./", "example./");
+    assert_urls_without_protocol("foo.example.", "foo.example.");
+    assert_urls_without_protocol("example.c", "example.c");
+    assert_urls_without_protocol("example.co", "|example.co|");
+    assert_urls_without_protocol("example.com", "|example.com|");
+    assert_urls_without_protocol("e.com", "|e.com|");
+    assert_urls_without_protocol("exampl.e.c", "exampl.e.c");
+    assert_urls_without_protocol("exampl.e.co", "|exampl.e.co|");
+    assert_urls_without_protocol("e.xample.c", "e.xample.c");
+    assert_urls_without_protocol("e.xample.co", "|e.xample.co|");
 }
 
 #[test]
@@ -458,12 +458,13 @@ fn assert_linked(input: &str, expected: &str) {
 }
 
 fn assert_not_linked_without_protocol(s: &str) {
-    assert_linked_without_protocol(s, s);
+    assert_urls_without_protocol(s, s);
 }
 
 /// Assert link without protocol
-fn assert_linked_without_protocol(input: &str, expected: &str) {
+fn assert_urls_without_protocol(input: &str, expected: &str) {
     let mut finder = LinkFinder::new();
     finder.url_must_have_scheme(false);
+    finder.kinds(&[LinkKind::Url]);
     assert_linked_with(&finder, input, expected);
 }

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -387,6 +387,7 @@ fn multiple_mixed_protocol() {
 
 #[test]
 fn international() {
+    assert_linked("http://üñîçøðé.com", "|http://üñîçøðé.com|");
     assert_linked("http://üñîçøðé.com/ä", "|http://üñîçøðé.com/ä|");
     assert_linked("http://example.org/\u{A1}", "|http://example.org/\u{A1}|");
     assert_linked("http://example.org/\u{A2}", "|http://example.org/\u{A2}|");
@@ -403,6 +404,7 @@ fn international() {
 
 #[test]
 fn international_without_protocol() {
+    assert_linked_without_protocol("üñîçøðé.com", "|üñîçøðé.com|");
     assert_linked_without_protocol("üñîçøðé.com/ä", "|üñîçøðé.com/ä|");
     assert_linked_without_protocol("example.org/\u{A1}", "|example.org/\u{A1}|");
     assert_linked_without_protocol("example.org/\u{A2}", "|example.org/\u{A2}|");

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -68,6 +68,18 @@ fn single_links() {
 }
 
 #[test]
+fn single_links_without_protocol() {
+    assert_linked_without_protocol("example.org/", "|example.org/|");
+    assert_linked_without_protocol("example.org/123", "|example.org/123|");
+    assert_linked_without_protocol(
+        "example.org/?foo=test&bar=123",
+        "|example.org/?foo=test&bar=123|",
+    );
+    assert_linked_without_protocol("example.org/?foo=%20", "|example.org/?foo=%20|");
+    assert_linked_without_protocol("example.org/%3C", "|example.org/%3C|");
+}
+
+#[test]
 fn space_characters_stop_url() {
     assert_linked("foo http://example.org/", "foo |http://example.org/|");
     assert_linked("http://example.org/ bar", "|http://example.org/| bar");
@@ -85,6 +97,17 @@ fn space_characters_stop_url() {
 }
 
 #[test]
+fn space_characters_stop_url_without_protocol() {
+    assert_linked_without_protocol("foo example.org/", "foo |example.org/|");
+    assert_linked_without_protocol("example.org/ bar", "|example.org/| bar");
+    assert_linked_without_protocol("example.org/\tbar", "|example.org/|\tbar");
+    assert_linked_without_protocol("example.org/\nbar", "|example.org/|\nbar");
+    assert_linked_without_protocol("example.org/\u{0B}bar", "|example.org/|\u{0B}bar");
+    assert_linked_without_protocol("example.org/\u{0C}bar", "|example.org/|\u{0C}bar");
+    assert_linked_without_protocol("example.org/\rbar", "|example.org/|\rbar");
+}
+
+#[test]
 fn illegal_characters_stop_url() {
     assert_linked("http://example.org/<", "|http://example.org/|<");
     assert_linked("http://example.org/>", "|http://example.org/|>");
@@ -94,6 +117,17 @@ fn illegal_characters_stop_url() {
     assert_linked("http://example.org/\u{7F}", "|http://example.org/|\u{7F}");
     assert_linked("http://example.org/\u{9F}", "|http://example.org/|\u{9F}");
     assert_linked("http://example.org/foo|bar", "|http://example.org/foo||bar");
+}
+
+#[test]
+fn illegal_characters_stop_url_without_protocol() {
+    assert_linked_without_protocol("example.org/<", "|example.org/|<");
+    assert_linked_without_protocol("example.org/>", "|example.org/|>");
+    assert_linked_without_protocol("example.org/<>", "|example.org/|<>");
+    assert_linked_without_protocol("example.org/\u{00}", "|example.org/|\u{00}");
+    assert_linked_without_protocol("example.org/\u{0E}", "|example.org/|\u{0E}");
+    assert_linked_without_protocol("example.org/\u{7F}", "|example.org/|\u{7F}");
+    assert_linked_without_protocol("example.org/\u{9F}", "|example.org/|\u{9F}");
 }
 
 #[test]
@@ -108,6 +142,17 @@ fn delimiter_at_end() {
 }
 
 #[test]
+fn delimiter_at_end_no_protocol() {
+    assert_linked_without_protocol("example.org/.", "|example.org/|.");
+    assert_linked_without_protocol("example.org/..", "|example.org/|..");
+    assert_linked_without_protocol("example.org/,", "|example.org/|,");
+    assert_linked_without_protocol("example.org/:", "|example.org/|:");
+    assert_linked_without_protocol("example.org/?", "|example.org/|?");
+    assert_linked_without_protocol("example.org/!", "|example.org/|!");
+    assert_linked_without_protocol("example.org/;", "|example.org/|;");
+}
+
+#[test]
 fn matching_punctuation() {
     assert_linked("http://example.org/a(b)", "|http://example.org/a(b)|");
     assert_linked("http://example.org/a[b]", "|http://example.org/a[b]|");
@@ -118,6 +163,18 @@ fn matching_punctuation() {
     assert_linked("{http://example.org/}", "{|http://example.org/|}");
     assert_linked("\"http://example.org/\"", "\"|http://example.org/|\"");
     assert_linked("'http://example.org/'", "'|http://example.org/|'");
+}
+#[test]
+fn matching_punctuation_without_protocol() {
+    assert_linked_without_protocol("example.org/a(b)", "|example.org/a(b)|");
+    assert_linked_without_protocol("example.org/a[b]", "|example.org/a[b]|");
+    assert_linked_without_protocol("example.org/a{b}", "|example.org/a{b}|");
+    assert_linked_without_protocol("example.org/a'b'", "|example.org/a'b'|");
+    assert_linked_without_protocol("(example.org/)", "(|example.org/|)");
+    assert_linked_without_protocol("[example.org/]", "[|example.org/|]");
+    assert_linked_without_protocol("{example.org/}", "{|example.org/|}");
+    assert_linked_without_protocol("\"example.org/\"", "\"|example.org/|\"");
+    assert_linked_without_protocol("'example.org/'", "'|example.org/|'");
 }
 
 #[test]
@@ -135,6 +192,20 @@ fn matching_punctuation_tricky() {
     assert_linked("http://example.org/(", "|http://example.org/|(");
     assert_linked("http://example.org/(.", "|http://example.org/|(.");
     assert_linked("http://example.org/]()", "|http://example.org/|]()");
+}
+
+#[test]
+fn matching_punctuation_tricky_without_protocol() {
+    assert_linked_without_protocol("((example.org/))", "((|example.org/|))");
+    assert_linked_without_protocol("((example.org/a(b)))", "((|example.org/a(b)|))");
+    assert_linked_without_protocol("[(example.org/)]", "[(|example.org/|)]");
+    assert_linked_without_protocol("(example.org/).", "(|example.org/|).");
+    assert_linked_without_protocol("(example.org/.)", "(|example.org/|.)");
+    assert_linked_without_protocol("example.org/>", "|example.org/|>");
+    // not sure about these
+    assert_linked_without_protocol("example.org/(", "|example.org/|(");
+    assert_linked_without_protocol("example.org/(.", "|example.org/|(.");
+    assert_linked_without_protocol("example.org/]()", "|example.org/|]()");
 }
 
 #[test]
@@ -160,6 +231,17 @@ fn single_quote() {
 }
 
 #[test]
+fn single_quote_without_protocol() {
+    assert_linked_without_protocol("example.org/\'_(foo)", "|example.org/\'_(foo)|");
+    assert_linked_without_protocol("example.org/\'_(foo)\'", "|example.org/\'_(foo)\'|");
+    assert_linked_without_protocol("example.org/\'\'", "|example.org/\'\'|");
+    assert_linked_without_protocol("example.org/\'\'\'", "|example.org/\'\'|\'");
+    assert_linked_without_protocol("example.org/\'.", "|example.org/|\'.");
+    assert_linked_without_protocol("example.org/\'a", "|example.org/\'a|");
+    assert_linked_without_protocol("example.org/it's", "|example.org/it's|");
+}
+
+#[test]
 fn double_quote() {
     // " not allowed in URLs
     assert_linked("http://example.org/\"a", "|http://example.org/|\"a");
@@ -182,6 +264,13 @@ fn asterisk() {
 }
 
 #[test]
+fn grave_quote_without_protocol() {
+    // ` not allowed in URLs
+    assert_linked_without_protocol("example.org/`a", "|example.org/|`a");
+    assert_linked_without_protocol("example.org/`a`", "|example.org/|`a`");
+}
+
+#[test]
 fn html() {
     assert_linked("http://example.org\">", "|http://example.org|\">");
     assert_linked("http://example.org'>", "|http://example.org|'>");
@@ -189,6 +278,16 @@ fn html() {
     assert_linked("http://example.org'/>", "|http://example.org|'/>");
     assert_linked("http://example.org<p>", "|http://example.org|<p>");
     assert_linked("http://example.org</p>", "|http://example.org|</p>");
+}
+
+#[test]
+fn html_no_protocol() {
+    assert_linked_without_protocol("example.org\">", "|example.org|\">");
+    assert_linked_without_protocol("example.org'>", "|example.org|'>");
+    assert_linked_without_protocol("example.org\"/>", "|example.org|\"/>");
+    assert_linked_without_protocol("example.org'/>", "|example.org|'/>");
+    assert_linked_without_protocol("example.org<p>", "|example.org|<p>");
+    assert_linked_without_protocol("example.org</p>", "|example.org|</p>");
 }
 
 #[test]
@@ -232,10 +331,23 @@ fn complex_html() {
 }
 
 #[test]
+fn css_without_protocol() {
+    assert_linked_without_protocol("example.org\");", "|example.org|\");");
+    assert_linked_without_protocol("example.org');", "|example.org|');");
+}
+
+#[test]
 fn slash() {
     assert_linked("http://example.org/", "|http://example.org/|");
     assert_linked("http://example.org/a/", "|http://example.org/a/|");
     assert_linked("http://example.org//", "|http://example.org//|");
+}
+
+#[test]
+fn slash_without_protocol() {
+    assert_linked_without_protocol("example.org/", "|example.org/|");
+    assert_linked_without_protocol("example.org/a/", "|example.org/a/|");
+    assert_linked_without_protocol("example.org//", "|example.org//|");
 }
 
 #[test]
@@ -251,6 +363,25 @@ fn multiple() {
     assert_linked(
         "(http://one.org/)(http://two.org/)",
         "(|http://one.org/|)(|http://two.org/|)",
+    );
+}
+#[test]
+fn multiple_without_protocol() {
+    assert_linked_without_protocol("one.org/ two.org/", "|one.org/| |two.org/|");
+    assert_linked_without_protocol("one.org/ : two.org/", "|one.org/| : |two.org/|");
+    assert_linked_without_protocol("(one.org/)(two.org/)", "(|one.org/|)(|two.org/|)");
+}
+
+#[test]
+fn multiple_mixed_protocol() {
+    assert_linked_without_protocol("http://one.org/ two.org/", "|http://one.org/| |two.org/|");
+    assert_linked_without_protocol(
+        "one.org/ : http://two.org/",
+        "|one.org/| : |http://two.org/|",
+    );
+    assert_linked_without_protocol(
+        "(http://one.org/)(two.org/)",
+        "(|http://one.org/|)(|two.org/|)",
     );
 }
 
@@ -271,6 +402,30 @@ fn international() {
 }
 
 #[test]
+fn international_without_protocol() {
+    assert_linked_without_protocol("üñîçøðé.com/ä", "|üñîçøðé.com/ä|");
+    assert_linked_without_protocol("example.org/\u{A1}", "|example.org/\u{A1}|");
+    assert_linked_without_protocol("example.org/\u{A2}", "|example.org/\u{A2}|");
+    assert_linked_without_protocol("example.org/\u{1F600}", "|example.org/\u{1F600}|");
+    assert_linked_without_protocol("example.org/\u{A2}/", "|example.org/\u{A2}/|");
+    assert_linked_without_protocol("xn--c1h.example.com/", "|xn--c1h.example.com/|");
+}
+
+#[test]
+fn skip_emails_without_protocol() {
+    assert_not_linked_without_protocol("foo.bar@example.org");
+}
+
+#[test]
+fn avoid_multiple_matches_without_protocol() {
+    let mut finder = LinkFinder::new();
+    finder.url_must_have_scheme(false);
+    let links: Vec<_> = finder.links("http://example.com").collect();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].as_str(), "http://example.com");
+}
+
+#[test]
 fn fuzz() {
     assert_not_linked("ab:/ϸ");
 }
@@ -279,7 +434,19 @@ fn assert_not_linked(s: &str) {
     assert_linked(s, s);
 }
 
+/// Assert link with protocol
 fn assert_linked(input: &str, expected: &str) {
     let finder = LinkFinder::new();
+    assert_linked_with(&finder, input, expected);
+}
+
+fn assert_not_linked_without_protocol(s: &str) {
+    assert_linked_without_protocol(s, s);
+}
+
+/// Assert link without protocol
+fn assert_linked_without_protocol(input: &str, expected: &str) {
+    let mut finder = LinkFinder::new();
+    finder.url_must_have_scheme(false);
     assert_linked_with(&finder, input, expected);
 }


### PR DESCRIPTION
### Implementation
This PR adds a toggle to make URL schemes such as `https` optional.

Normally only `https://example.com/` would be found in the text below.

```
Link to https://example.com/ and a reference to timvisee.com as well (shameless plug).
```

By explicitly toggling to make schemes optional, the link finder will find `timvisee.com` as well, like this:

```rust
let mut finder = LinkFinder::new();
finder.url_must_have_scheme(false);

finder.links(text).for_each(|link| {
    println!("Found: {:?} (type: {:?})", link.as_str(), link.type());
});

// Found: "https://example.com/" (type: LinkKind::Url)
// Found: "timvisee.com" (type: LinkKind::Url)
```

As seen in the snippet above links with or without a scheme share `LinkKind::Url` to prevent cluttering types for weird (upcoming) variants and edge cases.

### Further notes

Setting the scheme as optional will lead to false positive finds, but it is up to the end user to filter this as discussed in #7.

This implementation will search for both `:` and `.` occurrences if searching with optional schemes. The great thing is that this will find `http://a` without a `.` separator, but when hitting URLs with no scheme a `.` separator is always present for a `host.TLD` combination. This will never find `abc` with no scheme, and no `.` separator. I hope I'm getting across what behavior I'm referring to here.

Because referring to 'https' as a scheme looks more correct, I renamed this feature to 'optional schemes'.

All current tests succeed. With simple manual testing it looks like the library is outputting correct results.

### TODO
This is a work in progress PR, and the following tasks must be completed first before finalizing:

- [x] Add optional scheme toggle
- [x] Correctly find URLs with optional schemes
- [x] Confirm the implementation looks correct (@robinst)
- [x] Update unit tests, test for URLs with no scheme as well
- [x] Ensure URLs aren't found multiple times when searching optional schemes using `.`.
- [x] Rebase on latest `master`
- [x] TLDs should have at least 2 characters

@robinst Feel free to work on the attached branch for any improvements if you desire. Please let me know what you think! I'm quite happy myself with this implementation.

Fixes #7 