### PR TITLE
Add test for parsing image URLs

### DIFF
--- a/tests/url.rs
+++ b/tests/url.rs
@@ -176,6 +176,14 @@ fn css() {
 }
 
 #[test]
+fn images() {
+    assert_linked(
+        r#"<img src="http://example.org/test.svg">"#,
+        r#"<img src="|http://example.org/test.svg|">"#,
+    );
+}
+
+#[test]
 fn slash() {
     assert_linked("http://example.org/", "|http://example.org/|");
     assert_linked("http://example.org/a/", "|http://example.org/a/|");
@@ -200,10 +208,7 @@ fn multiple() {
 
 #[test]
 fn international() {
-    assert_linked(
-        "http://üñîçøðé.com/ä",
-        "|http://üñîçøðé.com/ä|",
-    );
+    assert_linked("http://üñîçøðé.com/ä", "|http://üñîçøðé.com/ä|");
     assert_linked("http://example.org/\u{A1}", "|http://example.org/\u{A1}|");
     assert_linked("http://example.org/\u{A2}", "|http://example.org/\u{A2}|");
     assert_linked(

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -184,6 +184,32 @@ fn images() {
 }
 
 #[test]
+fn complex_html() {
+    assert_linked(
+        r#"<div><a href="http://example.org"></a></div>"#,
+        r#"<div><a href="|http://example.org|"></a></div>"#,
+    );
+
+    assert_linked(
+        r#"<div><a href="http://example.org"
+        ></a></div>"#,
+        r#"<div><a href="|http://example.org|"
+        ></a></div>"#,
+    );
+
+    assert_linked(
+        r#"<div>
+       <img
+         src="http://example.org/test3.jpg" />
+     </div>"#,
+        r#"<div>
+       <img
+         src="|http://example.org/test3.jpg|" />
+     </div>"#,
+    )
+}
+
+#[test]
 fn slash() {
     assert_linked("http://example.org/", "|http://example.org/|");
     assert_linked("http://example.org/a/", "|http://example.org/a/|");


### PR DESCRIPTION
Over at https://github.com/lycheeverse/lychee-action/issues/5, we are facing issues with parsing file URLs, specifically inside HTML. Initially I thought the issue was with linkify, so I wrote a quick test to verify my assumption.
Turns out this is not the case and linkify is doing fine. The bug must be elsewhere.
Nevertheless I was wondering if it's a good idea to add a test for file types to make sure that the parsing doesn't break in the future. 
I kept the HTML part because I think it's a very common case to have image URLs embedded inside HTML.
Let me know what you think and if I should simplify the test. 