### PR TITLE
Match protocol relative URLs (`://`)

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -25,7 +25,7 @@ pub enum Trigger {
     Colon,
     Slash,
     _At,
-    /// Users should not exhaustively match this enum, because more link types
+    /// Users should not exhaustively match this enum, because more trigger types
     /// may be added in the future.
     #[doc(hidden)]
     __Nonexhaustive,

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -21,11 +21,14 @@ pub struct Link<'t> {
 /// Users should not exhaustively match this enum, because more triggers
 /// may be added in the future.
 #[derive(Debug, PartialEq)]
-#[non_exhaustive]
 pub enum Trigger {
     Colon,
     Slash,
     _At,
+    /// Users should not exhaustively match this enum, because more link types
+    /// may be added in the future.
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<'t> Link<'t> {

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -17,6 +17,17 @@ pub struct Link<'t> {
     kind: LinkKind,
 }
 
+/// The type of trigger used for scanning the input
+/// Users should not exhaustively match this enum, because more triggers
+/// may be added in the future.
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Trigger {
+    Colon,
+    Slash,
+    _At,
+}
+
 impl<'t> Link<'t> {
     /// The start index of the link within the input text.
     #[inline]
@@ -215,9 +226,9 @@ impl<'t> Iterator for Links<'t> {
         while let Some(i) = (self.trigger_finder)(slice[find_from..].as_bytes()) {
             let trigger = slice.as_bytes()[find_from + i];
             let (scanner, kind): (&dyn Scanner, LinkKind) = match trigger {
-                b':' => (&UrlScanner { trigger: ':' }, LinkKind::Url),
+                b':' => (&UrlScanner { trigger: Trigger::Colon }, LinkKind::Url),
                 b'@' => (&self.email_scanner, LinkKind::Email),
-                b'/' => (&UrlScanner { trigger: '/' }, LinkKind::Url),
+                b'/' => (&UrlScanner { trigger: Trigger::Slash }, LinkKind::Url),
                 _ => unreachable!(),
             };
             if let Some(range) = scanner.scan(slice, find_from + i) {

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -21,6 +21,7 @@ fn schemes() {
     assert_not_linked("-://foo");
     assert_not_linked(".://foo");
     assert_not_linked("1abc://foo");
+    assert_linked("//foo", "|//foo|");
     assert_linked("a://foo", "|a://foo|");
     assert_linked("a123://foo", "|a123://foo|");
     assert_linked("a123b://foo", "|a123b://foo|");


### PR DESCRIPTION
Protocol-relative links (PRL), also known as protocol-relative URLs (PRURL), are URLs that have no protocol specified. For example, `//example.com` will use the protocol of the current page, typically HTTP or HTTPS.

These URLs commonly occur in the wild, specifically on pages that support both HTTP and HTTPS protocols.

Since the URLs without a protocol belong to the class of relative URLs, it is up to the user to decide what protocol to use when parsing these URLs.
Example configuration for the url crate: https://docs.rs/url/2.2.1/url/#base-url

It would be great to support those in linkify, as I discovered quite a few cases while working on recursion in lychee.
(https://github.com/lycheeverse/lychee/pull/165)