### PR TITLE
Add tests for ipv4/ipv6 local addresses

### DIFF
--- a/tests/url.rs
+++ b/tests/url.rs
@@ -44,6 +44,14 @@ fn authority() {
 }
 
 #[test]
+fn local_links() {
+    assert_linked("http://127.0.0.1", "|http://127.0.0.1|");
+    assert_linked("http://127.0.0.1/", "|http://127.0.0.1/|");
+    assert_linked("http://::1", "|http://::1|");
+    assert_linked("http://::1/", "|http://::1/|");
+}
+
+#[test]
 fn single_links() {
     assert_linked("ab://c", "|ab://c|");
     assert_linked("http://example.org/", "|http://example.org/|");


### PR DESCRIPTION
I wasn't sure if linkify was properly detecting local addresses, so I looked at the tests and couldn't find these test-cases. Unless I've overlooked something, they seem to be missing. Local addresses (e.g. http://127.0.0.1) work as expected, but perhaps we could add a test so they won't break in the future without notice.