### PR TITLE
Stop URL parsing on pipe character (|)

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -67,11 +67,11 @@ impl UrlScanner {
 
         for (i, c) in s.char_indices() {
             let can_be_last = match c {
-                '\u{00}'..='\u{1F}' | ' ' | '\"' | '<' | '>' | '`' | '\u{7F}'..='\u{9F}' => {
+                '\u{00}'..='\u{1F}' | ' ' | '|' |  '\"' | '<' | '>' | '`' | '\u{7F}'..='\u{9F}' => {
                     // These can never be part of an URL, so stop now. See RFC 3986 and RFC 3987.
                     // Some characters are not in the above list, even they are not in "unreserved"
                     // or "reserved":
-                    //   '\\', '^', '{', '|', '}'
+                    //   '\\', '^', '{', '}'
                     // The reason for this is that other link detectors also allow them. Also see
                     // below, we require the braces to be balanced.
                     break;

--- a/src/url.rs
+++ b/src/url.rs
@@ -67,7 +67,7 @@ impl UrlScanner {
 
         for (i, c) in s.char_indices() {
             let can_be_last = match c {
-                '\u{00}'..='\u{1F}' | ' ' | '|' |  '\"' | '<' | '>' | '`' | '\u{7F}'..='\u{9F}' => {
+                '\u{00}'..='\u{1F}' | ' ' | '|' | '\"' | '<' | '>' | '`' | '\u{7F}'..='\u{9F}' => {
                     // These can never be part of an URL, so stop now. See RFC 3986 and RFC 3987.
                     // Some characters are not in the above list, even they are not in "unreserved"
                     // or "reserved":

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -85,6 +85,7 @@ fn illegal_characters_stop_url() {
     assert_linked("http://example.org/\u{0E}", "|http://example.org/|\u{0E}");
     assert_linked("http://example.org/\u{7F}", "|http://example.org/|\u{7F}");
     assert_linked("http://example.org/\u{9F}", "|http://example.org/|\u{9F}");
+    assert_linked("http://example.org/foo|bar", "|http://example.org/foo||bar");
 }
 
 #[test]


### PR DESCRIPTION
According to the comments, allowing the pipe character in URLs was a deliberate decision as other link detectors also allow them.
I wonder if we could revert that decision for pipes, as we run into some problems with that over on lychee, see https://github.com/lycheeverse/lychee/issues/210.
As far as I can see, it doesn't affect the testing library or the rest of the code.
If that is not an option, perhaps we could consider introducing a `strict` flag, which would allow the library to adhere to RFC 3986 and RFC 3987?
