### PR TITLE
Add support for skipping wildcard URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ https://example.com/
 
 ## Usage
 
-Basic usage:
+### Basic usage
 
 ```rust
 extern crate linkify;
@@ -66,7 +66,7 @@ assert_eq!(32, link.end());
 assert_eq!(&LinkKind::Url, link.kind());
 ```
 
-Option to allow URLs without schemes:
+### Option to allow URLs without schemes
 
 ```rust
 use linkify::LinkFinder;
@@ -81,7 +81,26 @@ let links: Vec<_> = finder.links(input).collect();
 assert_eq!(links[0].as_str(), "example.org/foo");
 ```
 
-Restrict the kinds of links:
+### Skip wildcard URLs
+
+By default, linkify also extracts wildcard URLs like
+http://*.example.org. You can disable that.
+
+
+```rust
+use linkify::LinkFinder;
+
+let input = "http://*.example.org";
+let mut finder = LinkFinder::new();
+
+// true by default
+finder.wildcards(false);
+
+let links: Vec<_> = finder.links(input).collect();
+assert!(links.is_empty());
+```
+
+### Restrict the kinds of links
 
 ```rust
 use linkify::{LinkFinder, LinkKind};

--- a/src/email.rs
+++ b/src/email.rs
@@ -11,7 +11,8 @@ pub struct EmailScanner {
 }
 
 impl Scanner for EmailScanner {
-    fn scan(&self, s: &str, at: usize) -> Option<Range<usize>> {
+    // Note: We currently don't extract email addresses containing wildcards
+    fn scan(&self, s: &str, at: usize, _extract_wildcard_urls: bool) -> Option<Range<usize>> {
         if let Some(start) = self.find_start(&s[0..at]) {
             let after = at + 1;
             if let Some(end) = self.find_end(&s[after..]) {
@@ -141,6 +142,6 @@ pub(crate) fn is_mail(input: &str) -> bool {
             let scanner = EmailScanner {
                 domain_must_have_dot: true,
             };
-            scanner.scan(input, i).is_some()
+            scanner.scan(input, i, true).is_some()
         })
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,5 +1,10 @@
 use std::ops::Range;
 
 pub trait Scanner {
-    fn scan(&self, s: &str, trigger_index: usize) -> Option<Range<usize>>;
+    fn scan(
+        &self,
+        s: &str,
+        trigger_index: usize,
+        extract_wildcard_urls: bool,
+    ) -> Option<Range<usize>>;
 }

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -443,6 +443,22 @@ fn avoid_multiple_matches_without_protocol() {
 }
 
 #[test]
+fn wildcard_urls() {
+    let finder = LinkFinder::new();
+    let links: Vec<_> = finder.links("http://*.example.com").collect();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].as_str(), "http://*.example.com");
+}
+
+#[test]
+fn no_wildcard_urls() {
+    let mut finder = LinkFinder::new();
+    finder.wildcards(false);
+    let links: Vec<_> = finder.links("http://*.example.com").collect();
+    assert!(links.is_empty());
+}
+
+#[test]
 fn fuzz() {
     assert_not_linked("ab:/ϸ");
 }


### PR DESCRIPTION
URLs can contain wildcards as in http://*.example.org.
These are commonly used in cases where listing all possible URLs would
not be feasible, e.g. when defining Content-Security-Policy rules [1].

It can be surprising to users of linkify that these URLs get extracted.
As such, this change adds support for disabling the extraction of wildcard
URLs.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

Fixes #37.