### PR TITLE
Don't require host for `file` scheme

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -136,7 +136,7 @@ fn find_scheme_start(s: &str) -> (Option<usize>, Option<char>) {
 /// We could make this configurable, but let's keep it simple until someone asks (hi!).
 fn scheme_requires_host(scheme: &str) -> bool {
     match scheme {
-        "https" | "http" | "file" | "ftp" | "ssh" => true,
+        "https" | "http" | "ftp" | "ssh" => true,
         _ => false,
     }
 }

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -39,6 +39,8 @@ fn authority() {
     assert_not_linked("file:// ");
     assert_not_linked("\"file://\"");
     assert_not_linked("\"file://...\", ");
+    assert_linked("file://somefile", "|file://somefile|");
+    assert_linked("file://../relative", "|file://../relative|");
     assert_linked("http://a.", "|http://a|.");
 }
 


### PR DESCRIPTION
In [0.9.0](https://github.com/robinst/linkify/blob/main/CHANGELOG.md#090---2022-07-11), URL parsing became more restrictive to avoid some false positives.
While the changes improved robustness, they had the side-effect of breaking a use-case for [lychee](https://github.com/lycheeverse/lychee), which allowed relative file paths as inputs.

For example, this works as expected and checks `somefile` for broken links:

```
echo 'file://somefile' | lychee -
```

However, relative paths don't work anymore:

```
echo 'file://../somefile' | lychee -
```

The link (and therefore the input) is no longer detected.

It looks like this is a regression, because linkify now requires a host for `file` schemes:
https://github.com/robinst/linkify/blob/b1d8e3c76e33118844626fe20489912ff51dc0dc/src/url.rs#L137-L142

In the above example, `somefile` is detected as the "host" (while it is more likely to be a filename in this case), whereas linkify doesn't detect a host in `../somefile`.

The fix is straightforward if we are willing to accept `file` URLs without a host again.
(On a more general note, I don't think the concept of a "host" applies to files anyway.)

I made the change and added a test and the fix does not affect any other use-cases, which makes me hopeful that this can be merged.

