### PR TITLE
Fix too lenient handling of e-mail addresses

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -89,7 +89,7 @@ impl EmailScanner {
             | '|'
             | '}'
             | '~' => true,
-            _ => c >= '\u{80}',
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
Removed the handling of code points above and including \u{80} in local_atom_allowed() as that isn't conforming to RFC5322 and leads to incorrect identification of e-mail links.