### PR TITLE
Issue 78 support ipv6

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -60,11 +60,34 @@ fn some_links_without_scheme(c: &mut Criterion) {
     });
 }
 
+fn ipv6_links(c: &mut Criterion) {
+    let finder = LinkFinder::new();
+
+    // performance of a standard, valid ipv6 link
+    c.bench_function("ipv6_standard", |b| {
+        b.iter(|| {
+            let links = finder.links("http://[2001:db8::1]:8080/path");
+            assert_eq!(links.count(), 1);
+        })
+    });
+
+    c.bench_function("ipv6_unclosed_bracket_fail_fast", |b| {
+        b.iter(|| {
+            let links = finder.links(
+                "http://[2001:db8::1_malformed_text_continues_on_and_on\
+			notice how it just keeps going on but doesnt end because there hasnt been a closing bracket",
+            );
+            assert_eq!(links.count(), 0);
+        })
+    });
+}
+
 criterion_group!(
     benches,
     no_links,
     some_links,
     heaps_of_links,
-    some_links_without_scheme
+    some_links_without_scheme,
+    ipv6_links
 );
 criterion_main!(benches);

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -34,8 +34,6 @@ pub(crate) fn find_authority_end(
     port_allowed: bool,
     iri_parsing_enabled: bool,
 ) -> (Option<usize>, Option<usize>) {
-    let mut end = Some(0);
-
     let mut maybe_last_dot = None;
     let mut last_dot = None;
     let mut number_dots = 0;
@@ -44,8 +42,10 @@ pub(crate) fn find_authority_end(
     let mut all_numeric = true;
     let mut maybe_host = true;
     let mut host_ended = false;
+    let mut end = Some(0);
+    let mut chars = s.char_indices();
 
-    for (i, c) in s.char_indices() {
+    while let Some((i, c)) = chars.next() {
         let can_be_last = match c {
             // ALPHA
             'a'..='z' | 'A'..='Z' | '\u{80}'..=char::MAX => {
@@ -161,12 +161,47 @@ pub(crate) fn find_authority_end(
                 }
                 break;
             }
-            _ => {
-                // Anything else, this might be the end of the authority (can be empty).
-                // Now let the rest of the code handle checking whether the end of the URL is
-                // valid.
-                break;
+            '[' => {
+                if maybe_host && !host_ended {
+                    let mut closed = false;
+                    let mut has_chars = false;
+                    let mut bracket_end_idx = i;
+
+                    // look for closing bracket and ipv6 characters in between.
+                    while let Some((inner_i, inner_c)) = chars.next() {
+                        match inner_c {
+                            ']' => {
+                                if has_chars {
+                                    closed = true;
+                                    bracket_end_idx = inner_i + inner_c.len_utf8();
+                                }
+                                break;
+                            }
+                            // Allow valid IPv6 characters + Zone Index alphanumeric
+                            '0'..='9' | 'a'..='z' | 'A'..='Z' | ':' | '.' | '%' => {
+                                has_chars = true;
+                            }
+                            _ => break, // Invalid character, abort
+                        }
+                    }
+
+                    if closed {
+                        // 4. Update state to reflect a successful host block
+                        all_numeric = false;
+                        maybe_last_dot = None;
+                        end = Some(bracket_end_idx);
+
+                        // The iterator is now sitting exactly on the character AFTER ']'.
+                        // We `continue` to let the outer loop process the next char (like ':' or '/')
+                        continue;
+                    } else {
+                        break; // Unclosed or malformed, terminate authority scanning
+                    }
+                } else {
+                    break;
+                }
             }
+            _ => break,
         };
 
         if can_be_last {

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -168,7 +168,7 @@ pub(crate) fn find_authority_end(
                     let mut bracket_end_idx = i;
 
                     // look for closing bracket and ipv6 characters in between.
-                    while let Some((inner_i, inner_c)) = chars.next() {
+                    for (inner_i, inner_c) in chars.by_ref() {
                         match inner_c {
                             ']' => {
                                 if has_chars {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use linkify::LinkFinder;
+use linkify::{LinkFinder, LinkKind};
 
 pub fn assert_linked_with(finder: &LinkFinder, input: &str, expected: &str) {
     let actual = show_links(input, finder);
@@ -18,4 +18,22 @@ pub fn show_links(input: &str, finder: &LinkFinder) -> String {
         }
     }
     result
+}
+
+/// Assert link without protocol
+pub fn assert_urls_without_protocol(input: &str, expected: &str) {
+    let mut finder = LinkFinder::new();
+    finder.url_must_have_scheme(false);
+    finder.kinds(&[LinkKind::Url]);
+    assert_linked_with(&finder, input, expected);
+}
+
+/// Assert link with protocol
+pub fn assert_linked(input: &str, expected: &str) {
+    let finder = LinkFinder::new();
+    assert_linked_with(&finder, input, expected);
+}
+
+pub fn assert_not_linked(s: &str) {
+    assert_linked(s, s);
 }

--- a/tests/ipv6.rs
+++ b/tests/ipv6.rs
@@ -1,0 +1,247 @@
+mod common;
+
+use crate::common::{assert_linked, assert_not_linked};
+
+#[test]
+fn ipv6_from_issue() {
+    // test the literal links from the pr.
+    assert_linked(
+        "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html",
+        "|http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html|",
+    );
+
+    assert_linked(
+        "http://[1080:0:0:0:8:800:200C:417A]/index.html",
+        "|http://[1080:0:0:0:8:800:200C:417A]/index.html|",
+    );
+
+    assert_linked(
+        "http://[3ffe:2a00:100:7031::1]",
+        "|http://[3ffe:2a00:100:7031::1]|",
+    );
+    assert_linked(
+        "http://[1080::8:800:200C:417A]/foo",
+        "|http://[1080::8:800:200C:417A]/foo|",
+    );
+
+    assert_linked("http://[::192.9.5.5]/ipng", "|http://[::192.9.5.5]/ipng|");
+
+    assert_linked(
+        "http://[::FFFF:129.144.52.38]:80/index.html",
+        "|http://[::FFFF:129.144.52.38]:80/index.html|",
+    );
+
+    assert_linked(
+        "http://[2010:836B:4179::836B:4179]",
+        "|http://[2010:836B:4179::836B:4179]|",
+    );
+}
+
+#[test]
+fn ipv6_full_uncompressed() {
+    assert_linked(
+        "http://[2001:0db8:0000:0000:0000:ff00:0042:8329]",
+        "|http://[2001:0db8:0000:0000:0000:ff00:0042:8329]|",
+    );
+}
+
+#[test]
+fn ipv6_leading_zeros_omitted() {
+    assert_linked(
+        "https://[2001:db8:0:0:0:ff00:42:8329]",
+        "|https://[2001:db8:0:0:0:ff00:42:8329]|",
+    );
+}
+
+#[test]
+fn ipv6_zero_comp_middle() {
+    assert_linked(
+        "https://[2001:db8::ff00:42:8329]",
+        "|https://[2001:db8::ff00:42:8329]|",
+    );
+}
+
+#[test]
+fn ipv6_zero_comp_trailing() {
+    assert_linked("http://[2001:db8:1234::]", "|http://[2001:db8:1234::]|");
+}
+
+#[test]
+fn ipv6_zero_comp_leading() {
+    assert_linked("http://[::1234:5678]", "|http://[::1234:5678]|");
+}
+
+#[test]
+fn ipv6_zero_comp_loopback_comp() {
+    assert_linked("https://[::1]", "|https://[::1]|");
+}
+
+#[test]
+fn ipv6_unspecified_address() {
+    assert_linked("http://[::]", "|http://[::]|");
+}
+
+// RFC 3986:
+
+#[test]
+fn ipv6_bracket_no_port() {
+    assert_linked("http://[2001:db8::1]", "|http://[2001:db8::1]|");
+}
+
+#[test]
+fn ipv6_bracket_with_port() {
+    assert_linked("http://[2001:db8::1]:8080", "|http://[2001:db8::1]:8080|");
+}
+
+#[test]
+fn ipv6_bracket() {
+    assert_linked("http://[2001:db8::1]", "|http://[2001:db8::1]|");
+}
+
+#[test]
+fn ipv6_bracket_slash() {
+    assert_linked("https://[2001:db8::1]/", "|https://[2001:db8::1]/|");
+}
+
+#[test]
+fn ipv6_bracket_path() {
+    assert_linked(
+        "http://[2001:db8::1]/index.html",
+        "|http://[2001:db8::1]/index.html|",
+    );
+}
+
+#[test]
+fn ipv6_mixed_case() {
+    assert_linked("http://[2001:DB8::A:b:C]", "|http://[2001:DB8::A:b:C]|");
+}
+
+#[test]
+fn ipv6_max_hex() {
+    assert_linked(
+        "http://[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]",
+        "|http://[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]|",
+    );
+}
+// rfc 4007
+#[test]
+fn ipv6_zone_indices() {
+    assert_linked(
+        "http://[fe80::1ff:fe23:4567:890a%eth0]",
+        "|http://[fe80::1ff:fe23:4567:890a%eth0]|",
+    );
+    assert_linked("http://[fe80::1%25]", "|http://[fe80::1%25]|");
+}
+// RFC 6874: IPv6 Zone Identifiers in URIs
+
+#[test]
+fn ipv6_zone_index_unencoded() {
+    // Strictly speaking, unencoded '%' is not RFC compliant for URIs,
+    // but it is extremely common in plain text and we want to capture it.
+    assert_linked("http://[fe80::1%eth0]", "|http://[fe80::1%eth0]|");
+}
+
+#[test]
+fn ipv6_zone_index_encoded() {
+    // This is the strict RFC 6874 compliant format (%25 is the URL encoding for %)
+    assert_linked("http://[fe80::1%25eth0]", "|http://[fe80::1%25eth0]|");
+}
+
+#[test]
+fn ipv6_zone_index_with_port() {
+    // Crucial: verify that the parser transitions correctly from the zone index
+    // to the port after the closing bracket.
+    assert_linked(
+        "https://[fe80::1%eth0]:8080",
+        "|https://[fe80::1%eth0]:8080|",
+    );
+    assert_linked(
+        "https://[fe80::1%25eth0]:8080",
+        "|https://[fe80::1%25eth0]:8080|",
+    );
+}
+
+#[test]
+fn ipv6_zone_index_with_path() {
+    // Verify that the parser transitions correctly from the zone index to the path.
+    assert_linked(
+        "http://[fe80::1%eth0]/api/data",
+        "|http://[fe80::1%eth0]/api/data|",
+    );
+    assert_linked(
+        "http://[fe80::1%25eth0]/api/data",
+        "|http://[fe80::1%25eth0]/api/data|",
+    );
+}
+
+#[test]
+fn ipv6_zone_index_with_port_and_path() {
+    assert_linked(
+        "http://[fe80::1%eth0]:443/api/data?query=1",
+        "|http://[fe80::1%eth0]:443/api/data?query=1|",
+    );
+}
+
+#[test]
+fn ipv6_zone_index_ipv4_mapped() {
+    // A rare but syntactically possible edge case
+    assert_linked(
+        "http://[::ffff:192.0.2.128%eth0]",
+        "|http://[::ffff:192.0.2.128%eth0]|",
+    );
+}
+
+#[test]
+fn ipv6_ipv4_mapped() {
+    assert_linked(
+        "http://[::ffff:192.0.2.128]",
+        "|http://[::ffff:192.0.2.128]|",
+    );
+    assert_linked(
+        "http://[0:0:0:0:0:ffff:192.0.2.128]",
+        "|http://[0:0:0:0:0:ffff:192.0.2.128]|",
+    );
+}
+
+#[test]
+fn ipv6_empty_brackets() {
+    assert_not_linked("http://[]/");
+}
+
+#[test]
+fn ipv6_unclosed_brackets() {
+    assert_not_linked("http://[2001:db8::1/index.html");
+}
+
+#[test]
+fn ipv6_non_hex() {
+    assert_not_linked("http://[this-is-not-hex]/");
+}
+
+#[test]
+fn ipv6_nested_brackets() {
+    assert_not_linked("http://[[::1]]/");
+}
+#[test]
+fn ipv6_unclosed_bracket_at_eof() {
+    assert_not_linked("http://[2001:");
+}
+
+#[test]
+fn ipv6_unclosed_bracket_with_path() {
+    assert_not_linked("http://[2001:/path");
+}
+
+#[test]
+fn ipv6_with_complicated_surrounding_input() {
+    assert_linked("So it's 8:10pm on or maybe its 1:21. time is an illusion. : anyway, [check out this link](http://[::])",
+				  "So it's 8:10pm on or maybe its 1:21. time is an illusion. : anyway, [check out this link](|http://[::]|)")
+}
+
+#[test]
+fn ipv6_with_too_many_colons() {
+    // linkify does not do deep validation whether an ipv4 address is VALID, it extracts structurally valid boundaries.
+    // so i'll do the same- otherwise we'd have to start counting colons and doing more complicated validations which...
+    // would impact performance.
+    assert_linked("http://[:::]", "|http://[:::]|");
+}

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -1,6 +1,9 @@
 mod common;
 
-use crate::common::assert_linked_with;
+use crate::common::{
+    assert_linked, assert_linked_with, assert_not_linked, assert_urls_without_protocol,
+};
+
 use linkify::{LinkFinder, LinkKind};
 
 #[test]
@@ -558,24 +561,6 @@ fn fuzz() {
     assert_not_linked("ab:/ϸ");
 }
 
-fn assert_not_linked(s: &str) {
-    assert_linked(s, s);
-}
-
-/// Assert link with protocol
-fn assert_linked(input: &str, expected: &str) {
-    let finder = LinkFinder::new();
-    assert_linked_with(&finder, input, expected);
-}
-
 fn assert_not_linked_without_protocol(s: &str) {
     assert_urls_without_protocol(s, s);
-}
-
-/// Assert link without protocol
-fn assert_urls_without_protocol(input: &str, expected: &str) {
-    let mut finder = LinkFinder::new();
-    finder.url_must_have_scheme(false);
-    finder.kinds(&[LinkKind::Url]);
-    assert_linked_with(&finder, input, expected);
 }


### PR DESCRIPTION
PR for [issue 78](https://github.com/robinst/linkify/issues/78)
    feature: support rfc-compliant bracketed ipv6 addresses in URLs.
    
    Updates URL parsing to support RFC 3986 and RFC 6874 bracketed IPv6 addresses within a valid URL scheme.
    - replaces the for loop in find_authority_end with a while let loop to handle ipv6 extraction which apparently allows rust to use a jump table
    - when an open bracket is encountered, standard domain validation is suspended. the parser validates ipv6 valid characters-- including zone identifiers aka percentage signs until the closing bracket is found
    - maintains near zero performance regression on standard plaintext by ensuring normal characters bypass the ipv6 branch stuff
    - adds dedicated ipv6 benchmark cases and a substantial number ipv ipv6 unit tests
    - centralizes some testing utilities into tests/common/mod.rs to prevent duplicating test logic/functionality.
    
    NOTE: this adds ipv6 addresses within valid schemes-- schemeless bracketed IPs are intentionally excluded to prevent performance regressions on standard text.

